### PR TITLE
Fix outlet in use

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ function WemoAccessory(log, device, enddevice) {
         if(device.deviceType === Wemo.DEVICE_TYPE.Insight) {
             this._client.on('insightParams', function(state, power){
                 //self.log('%s inUse: %s', this.name, state);
-                self.inUse = state === 1 ? true : false ;
+                self.inUse = state == 1 ? true : false ;
                 self.powerUsage = Math.round(power / 100) / 10;
 
                 if (self.service) {


### PR DESCRIPTION
The Outlet In Use does not work for Insight devices. Seems the binary state comes through as a string so it cannot be compared with `===`.

This PR changes to `==` and I've tested this fixes the issue. Let me know if you prefer `===` with a string `'1'` instead and I'll change it.