### PR TITLE
Re-discover devices periodically to recover from errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,10 +51,10 @@ function WemoPlatform(log, config) {
     this.expectedAccessories = parseInt(config.expected_accessories) || 0; // default to false if not specficied
     this.timeout = config.timeout || 10; // default to 10 seconds if not specified
     this.homekitSafe = (isNaN(parseInt(config.homekit_safe, 10)) ) ? true : parseInt(config.homekit_safe, 10) > 0 ? true : false;
-        
+
     // if we have been not been told how many accessories to find then homekit safe is off.
     if(!this.expectedAccessories) { this.homekitSafe = false; }
-    
+
     noMotionTimer = config.no_motion_timer || 60;
 }
 
@@ -99,7 +99,7 @@ WemoPlatform.prototype = {
                 }
         });
 
-        // we'll wait here for the accessories to be found unless the specified number of 
+        // we'll wait here for the accessories to be found unless the specified number of
         // accessories has already been found in which case the timeout is cancelled!!
 
         var timer = setTimeout(function () {
@@ -197,9 +197,9 @@ function WemoAccessory(log, device, enddevice) {
 
 WemoAccessory.prototype._statusChange = function(deviceId, capabilityId, value) {
     /*
-         We recieve this notification if the wemo's are changed by Homekit (i.e us) or 
+         We recieve this notification if the wemo's are changed by Homekit (i.e us) or
          some other trigger (i.e. any of the pethora of wemo apps).
-         We want to update homekit with these changes, 
+         We want to update homekit with these changes,
          to do that we need to use setValue which triggers another call back to here which
          we need to ignore - much of this function deals with the idiosyncrasies around this issue.
     */
@@ -208,9 +208,9 @@ WemoAccessory.prototype._statusChange = function(deviceId, capabilityId, value) 
         this.log('statusChange Ignored (device): ', this.enddevice.deviceId, deviceId, capabilityId, value);
         return;
         }
-    
+
     if (this._capabilities[capabilityId] === value) {
-        // nothing's changed - lets get out of here to stop an endless loop as 
+        // nothing's changed - lets get out of here to stop an endless loop as
         // this callback was probably triggered by us updating HomeKit
         this.log('statusChange Ignored (capability): ', deviceId, capabilityId, value);
         return;
@@ -220,36 +220,36 @@ WemoAccessory.prototype._statusChange = function(deviceId, capabilityId, value) 
 
     // update our internal array with newly passed value.
     this._capabilities[capabilityId] = value;
-    
+
     switch(capabilityId) {
         case '10008': // this is a brightness change
             // update our convenience variable ASAP to minimise race condition possibiities
             var newbrightness = Math.round(this._capabilities['10008'].split(':').shift() / 255 * 100 );
- 
+
             // changing wemo bulb brightness always turns them on so lets reflect this locally and in homekit.
             // do we really need this or do we get both status change messages from wemo?
             if (!this.onState){ // if off
 //                 this.onState = true; // change convenience variable to on and call homekit which will trigger another ignored statusChange
                 this.log('Update homekit onState: %s is %s', this.name, true);
-                this._capabilities['10006'] = '1'; 
+                this._capabilities['10006'] = '1';
                 this.service.getCharacteristic(Characteristic.On).setValue(true);
                 }
-            
+
             // call setValue to update HomeKit and iOS (this generates another statusChange that will get ignored)
             this.log('Update homekit brightness: %s is %s', this.name, newbrightness);
             this.service.getCharacteristic(Characteristic.Brightness).setValue(newbrightness);
 
 
             break;
-            
+
         case '10006': // on/off/etc
             // reflect change of onState from potentially and external change (from Wemo App for instance)
             var newState = (this._capabilities['10006'].substr(0,1) === '1') ? true : false;
-            // similarly we need to update iOS with this change - which will trigger another state shange which we'll ignore    
+            // similarly we need to update iOS with this change - which will trigger another state shange which we'll ignore
             this.log('Update homekit onState: %s is %s', this.name, newState);
             this.service.getCharacteristic(Characteristic.On).setValue(newState);
             break;
-            
+
         default:
             console.log("This capability (%s) not implemented", capabilityId);
     }
@@ -328,7 +328,7 @@ WemoAccessory.prototype.setOn = function (value, cb) {
 //         this.log("setOn: %s to %s", this.name, value > 0 ? "on" : "off");
         this._client.setBinaryState(value ? 1 : 0, function (err){
             if(!err) {
-                this.log("setOn: %s to %s", this.name, value > 0 ? "on" : "off");                
+                this.log("setOn: %s to %s", this.name, value > 0 ? "on" : "off");
                 this.onState = value;
                 if (cb) cb(null);
             } else {
@@ -387,7 +387,7 @@ WemoAccessory.prototype.setOnStatus = function (value, cb) {
         this._client.setDeviceStatus(this.enddevice.deviceId, 10006, (value ? 1 : 0));
     }
     if (cb) cb(null);
-    
+
 }
 
 WemoAccessory.prototype.getOnStatus = function (cb) {

--- a/index.js
+++ b/index.js
@@ -64,7 +64,8 @@ WemoPlatform.prototype = {
             this.expectedAccessories ? this.expectedAccessories : "an unknown number" , this.timeout);
         var foundAccessories = [];
         var self = this;
-        wemo.discover(function (device) {
+
+		function foundDevice(device)  {
             self.log("Found: %s, type: %s", device.friendlyName, device.deviceType.split(":")[3]);
             if (device.deviceType === Wemo.DEVICE_TYPE.Bridge) { // a wemolink bridge - find bulbs
                 var client = this.client(device , self.log);
@@ -97,7 +98,19 @@ WemoPlatform.prototype = {
                     callback(foundAccessories);
                     }
                 }
-        });
+        }
+
+        wemo.discover(foundDevice);
+
+
+
+		// Repeat discovery as some devices may appear late
+		setInterval(function() {
+			if (foundAccessories.length !== self.expectedAccessories) {
+				wemo.discover(foundDevice);
+			}
+		}, self.timeout * 250);
+
 
         // we'll wait here for the accessories to be found unless the specified number of
         // accessories has already been found in which case the timeout is cancelled!!

--- a/index.js
+++ b/index.js
@@ -265,6 +265,10 @@ function WemoAccessory(log, accessory, device) {
     this.onState = false;
     this.service = this.getService();
 
+    this.client.on('error', function(err) {
+        self.log('%s reported error %s', self.accessory.displayName, err.code);
+    });
+
     this.updateReachability(true);
 
     this.accessory.getService(Service.AccessoryInformation)
@@ -525,6 +529,10 @@ function WemoLinkAccessory(log, accessory, link, device) {
     this.onState = false;
     this.brightness = null;
 
+    this.client.on('error', function(err) {
+        self.log('%s reported error %s', self.accessory.displayName, err.code);
+    });
+
     this.updateReachability(true);
 
     this.accessory.getService(Service.AccessoryInformation)
@@ -547,10 +555,6 @@ function WemoLinkAccessory(log, accessory, link, device) {
     // register eventhandler
     this.client.on('statusChange', function(deviceId, capabilityId, value) {
         self.statusChange(deviceId, capabilityId, value);
-    });
-
-    this.client.on('error', function(err) {
-        self.log('%s reported error %s', self.accessory.displayName, err.code);
     });
 }
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@
 var Accessory, Characteristic, PowerConsumption, Service, uuid;
 var Wemo = require('wemo-client');
 var wemo = new Wemo();
+wemo.shouldEmitErrors = false;
 var debug = require('debug')('homebridge-platform-wemo');
 
 var noMotionTimer;

--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@
 var Accessory, Characteristic, PowerConsumption, Service, uuid;
 var Wemo = require('wemo-client');
 var wemo = new Wemo();
-wemo.shouldEmitErrors = false;
 var debug = require('debug')('homebridge-platform-wemo');
 
 var noMotionTimer;
@@ -190,6 +189,10 @@ function WemoAccessory(log, device, enddevice) {
                     self._onState = self.onState;
                 }
             }
+        }.bind(this));
+
+        this._client.on('error', function(error) {
+          self.log('error: ' + error);
         }.bind(this));
 
         if(device.deviceType === Wemo.DEVICE_TYPE.Insight) {

--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@
 var Accessory, Characteristic, PowerConsumption, Service, uuid;
 var Wemo = require('wemo-client');
 var wemo = new Wemo();
-wemo.shouldEmitErrors = false;
 var debug = require('debug')('homebridge-platform-wemo');
 
 var noMotionTimer;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "request": "^2.65.0",
-    "wemo-client": "https://github.com/rudders/wemo-client.git",
+    "wemo-client": ">=0.11.0",
     "debug": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-wemo",
-  "version": "0.6.9",
+  "version": "0.7.0",
   "description": "WeMo Platform plugin for homebridge - Blubs, Switches and Insight Switches Supported",
   "license": "ISC",
   "keywords": [
@@ -8,7 +8,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/rudders/homebridge-platform-wemo.git"
+    "url": "git://github.com/joein3d/homebridge-platform-wemo.git"
   },
   "engines": {
     "node": ">=0.12.0",
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "request": "^2.65.0",
-    "wemo-client": ">=0.11.0",
+    "wemo-client": "git@github.com:joein3d/wemo-client.git",
     "debug": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "request": "^2.65.0",
-    "wemo-client": "git@github.com:joein3d/wemo-client.git",
+    "wemo-client": ">=0.11.0",
     "debug": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/joein3d/homebridge-platform-wemo.git"
+    "url": "git://github.com/rudders/homebridge-platform-wemo.git"
   },
   "engines": {
     "node": ">=0.12.0",


### PR DESCRIPTION
Summary of changes:

- Upgrade to the latest version of wemo-client and use the new built-in error events to detect network errors
- Periodically run discovery to catch devices that have errored out - re-setup the accessory with the updated device