### PR TITLE
Plugin v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+
+# Mac
+.DS_Store
+
+# Node
+node_modules/
+npm-debug.log
+.node-version

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 node_modules/
 npm-debug.log
 .node-version
+
+*.bak

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Configuration sample:
 
 ```
 
-The module will try and find all your WeMo Devices and make them available to HomeBridge / HomeKit / Siri.
+The module will try and find all your WeMo Devices and make them available to HomeBridge / HomeKit / Siri. It will use the name you have set up with the Belkin app as the name used for Homekit and hence Siri so ensure your naming is distinct so poor Siri has some chance of getting you commands right. To change a name simply use the Wemo App on your smartphone and restart homebridge to pick up the changes.
 
 The discovery process can be a little hit or miss with the Wemo platform so if all your devices are not discovered try restarting homebridge a few times and make sure all Lights (Bulbs) are on!
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ Configuration sample:
 
 ```
 
-The module will try and find all your WeMo Devices and make them available to HoomeBridge / HomeKit / Siri.
+The module will try and find all your WeMo Devices and make them available to HomeBridge / HomeKit / Siri.
+
+# ToDo
+
+The code needs some work to increase the speed of status checking by persisting the WemoClient objects I am using (amateur!). I'll get to this shortly and release a new version that also depends on Timon Reinhard's core wemo-client project not my derived version.
 
 # Credits
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,23 @@
 # homebridge-platform-wemo
 
-Belkin WeMo plugin for the awesome  [Homebridge](https://github.com/nfarina/homebridge) project.  
+Belkin WeMo Platform plugin for the awesome  [Homebridge](https://github.com/nfarina/homebridge) project.
+
+Currently supports
+- Wemo Switch
+- Wemo Insight Switch (on/off only)
+- Wemo Bulb (via Wemo Link - on/off/brightness)
 
 # Installation
 
 1. Install homebridge using: npm install -g homebridge
 2. Install this plugin using: npm install -g homebridge-platform-wemo
 3. Update your configuration file. See the sample below.
+
+# Updating
+
+Recently refactored to increase speed of operation and update on/off/brightness status more reliably.
+
+1. npm update -g homebridge-platform-wemo
 
 # Configuration
 
@@ -31,11 +42,13 @@ The module will try and find all your WeMo Devices and make them available to Ho
 
 # ToDo
 
-The code needs some work to increase the speed of status checking by persisting the WemoClient objects I am using (amateur!). I'll get to this shortly and release a new version that also depends on Timon Reinhard's core wemo-client project not my derived version.
+The code was recently updated to increase the speed of status checking by persisting the WemoClient objects properly.
 
 # Credits
 
-Credit goes to Timon Reinhard for his awesome [Wemo Client](https://github.com/timonreinhard/wemo-client) module and Andy Lindeman for the [homebridge-smartthings](https://github.com/alindeman/homebridge-smartthings) that this is work is based on.
+Credit goes to
+- Timon Reinhard for his awesome [Wemo Client](https://github.com/timonreinhard/wemo-client) module and advise 
+- Andy Lindeman for the [homebridge-smartthings](https://github.com/alindeman/homebridge-smartthings) that this is work is based on.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Configuration sample:
  ```javascript
 "platforms": [
         {
-          "platform": "WeMo",
+          "platform": "BelkinWeMo",
           "name": "WeMo Platform",
           "expected_accessories" : "x",
           "timeout" : "y"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # homebridge-platform-wemo
 [![NPM Version](https://img.shields.io/npm/v/homebridge-platform-wemo.svg)](https://www.npmjs.com/package/homebridge-platform-wemo)
+[![Code Climate](https://codeclimate.com/github/rudders/homebridge-platform-wemo/badges/gpa.svg)](https://codeclimate.com/github/rudders/homebridge-platform-wemo)
 
 Belkin WeMo Platform plugin for the awesome  [Homebridge](https://github.com/nfarina/homebridge) project.
 
-Currently supports
+## Currently supports
 - Wemo Switch
 - Wemo Light Swicth 
 - Wemo Insight Switch (on/off/outlineinuse only)
@@ -27,11 +28,13 @@ Recently refactored to increase speed of operation and update on/off/brightness 
 
 Configuration sample:
 
-`expected_accessories` is **optional**, defaults to unlimited and is the total count of Wemo bulbs, switches, etc that we will try to find. It essentially shrtcuts the `timeout` value - i.e. if we find the specified number of accessories we'l not bother with the timeout.
+`expected_accessories` is **optional**, defaults to unlimited and is the total count of Wemo bulbs, switches, etc that we will try to find. It is **HIGHLY RECOMMENDED** that you set this value - refer to homekit_safe parameter for reasoning. It has two purposes - we can shortcuts the `timeout` value when we know we can stop looking and more importantly tells us that if we can;t find this number of accessories on a restart that we should kill homebridge so that HomeKit doesn't get inadvertently updated.
 
-`timeout` is **optional**, defaults to 10 and if specified, in seconds, defines how long we will wait to find the specified number of `expected_accessories`
+`timeout` is **optional**, defaults to 10 and if specified, in seconds, defines how long we will wait to try and find the specified number of `expected_accessories`
 
 `no_motion_timer` is optional, defaults to 60 and applies to WeMo Motion Only. It is a timer in seconds for how long after motion is not detected that the state is changed.
+
+`homekit_safe` is option, defaults to 1 (true) if you have specified a number of `expected_accessories` or '0' (false) if you have not set an expectation as to the number of accessories. This parameter, when set to true, will cause homebridge to crash and hence not update HomeKit if it doesn't find the nominated number of accessories. See section below.
 
 
  ```javascript
@@ -41,7 +44,8 @@ Configuration sample:
           "name": "WeMo Platform",
           "expected_accessories" : "0",
           "timeout" : "25",
-          "no_motion_timer": "60"
+          "no_motion_timer": "60",
+          "homekit_safe" : "1"
         }   
     ]
 
@@ -51,9 +55,13 @@ The module will try and find all your WeMo Devices and make them available to Ho
 
 The discovery process can be a little hit or miss with the Wemo platform so if all your devices are not discovered try restarting homebridge a few times and make sure all Lights (Bulbs) are on!
 
+# homekit_safe
+
+There is an unfortunate side effect of Homebridge and HomeKit - in the situation where an accessory that has previously been found by homebridge and hence added to HomeKit is not found on a subsequent re-run of Homebridge. The side effect is the deletion of that accessory definition from HomeKit. Which has the knock-on effect that all the rooms/zones/scenes it was previously assigned to get updated with the device gone. This plugin will takes a brute force approach to the situation where it can't find the specified number of `expected_accessories` and crash homebridge.
+
 # ToDo
 
-The code was recently updated to increase the speed of status checking by persisting the WemoClient objects properly.
+Update to increase the speed of status checking by persisting the WemoClient objects properly - work is in progress and may remove the necessity for the brute force crashing of homebridge if the expected number of devices isn't found.
 
 # Credits
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ Belkin WeMo Platform plugin for the awesome  [Homebridge](https://github.com/nfa
 
 Currently supports
 - Wemo Switch
-- Wemo Light Swicth (please test and report issues)
-- Wemo Insight Switch (on/off only - please test and report issues)
+- Wemo Light Swicth 
+- Wemo Insight Switch (on/off only)
 - Wemo Bulb (via Wemo Link - on/off/brightness)
+- Wemo Motion
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# homebridge-platform-wemo
+
+Belkin WeMo plugin for the awesome  [Homebridge](https://github.com/nfarina/homebridge) project.  
+
+# Installation
+
+1. Install homebridge using: npm install -g homebridge
+2. Install this plugin using: npm install -g homebridge-playtform-wemo
+3. Update your configuration file. See the sample below.
+
+# Configuration
+
+Configuration sample:
+
+`expected_accessories` is the count of Wemo bulbs and switches you have - it is optional and if not specified the `timeout` value will be used to wait for the discovery process to conclude. 
+`timeout` is specified in seconds and will default to 10 seconds.
+
+ ```javascript
+"platforms": [
+        {
+          "platform": "WeMo",
+          "name": "WeMo Platform",
+          "expected_accessories" : "x",
+          "timeout" : "y"
+        }   
+    ]
+
+```
+
+The module will try and find all your WeMo Devices and make them available to HoomeBridge / HomeKit / Siri.
+
+# Credits
+
+Credit goes to Timon Reinhard for his awesome [Wemo Client](https://github.com/timonreinhard/wemo-client) module and Andy Lindeman for the [homebridge-smartthings](https://github.com/alindeman/homebridge-smartthings) that this is work is based on.
+
+# License
+
+Published under the MIT License.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ Belkin WeMo Platform plugin for the awesome  [Homebridge](https://github.com/nfa
 Currently supports
 - Wemo Switch
 - Wemo Light Swicth 
-- Wemo Insight Switch (on/off only)
+- Wemo Insight Switch (on/off/outlineinuse only)
 - Wemo Bulb (via Wemo Link - on/off/brightness)
 - Wemo Motion
+- Wemo NetCam (Sensor)
 
 # Installation
 
@@ -25,16 +26,21 @@ Recently refactored to increase speed of operation and update on/off/brightness 
 
 Configuration sample:
 
-`expected_accessories` is the count of Wemo bulbs and switches you have - it is optional and if not specified the `timeout` value will be used to wait for the discovery process to conclude. 
-`timeout` is specified in seconds and will default to 10 seconds.
+`expected_accessories` is **optional**, defaults to unlimited and is the total count of Wemo bulbs, switches, etc that we will try to find. It essentially shrtcuts the `timeout` value - i.e. if we find the specified number of accessories we'l not bother with the timeout.
+
+`timeout` is **optional**, defaults to 10 and if specified, in seconds, defines how long we will wait to find the specified number of `expected_accessories`
+
+`no_motion_timer` is optional, defaults to 60 and applies to WeMo Motion Only. It is a timer in seconds for how long after motion is not detected that the state is changed.
+
 
  ```javascript
 "platforms": [
         {
           "platform": "BelkinWeMo",
           "name": "WeMo Platform",
-          "expected_accessories" : "x",
-          "timeout" : "y"
+          "expected_accessories" : "0",
+          "timeout" : "25",
+          "no_motion_timer": "60"
         }   
     ]
 
@@ -53,6 +59,7 @@ The code was recently updated to increase the speed of status checking by persis
 Credit goes to
 - Timon Reinhard for his awesome [Wemo Client](https://github.com/timonreinhard/wemo-client) module and advise 
 - Andy Lindeman for the [homebridge-smartthings](https://github.com/alindeman/homebridge-smartthings) that this is work is based on.
+- [David Perry](https://github.com/devbobo) for his contributions.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Belkin WeMo Platform plugin for the awesome  [Homebridge](https://github.com/nfa
 
 Currently supports
 - Wemo Switch
-- Wemo Insight Switch (on/off only)
+- Wemo Light Swicth (please test and report issues)
+- Wemo Insight Switch (on/off only - please test and report issues)
 - Wemo Bulb (via Wemo Link - on/off/brightness)
 
 # Installation
@@ -39,6 +40,8 @@ Configuration sample:
 ```
 
 The module will try and find all your WeMo Devices and make them available to HomeBridge / HomeKit / Siri.
+
+The discovery process can be a little hit or miss with the Wemo platform so if all your devices are not discovered try restarting homebridge a few times and make sure all Lights (Bulbs) are on!
 
 # ToDo
 

--- a/index.js
+++ b/index.js
@@ -184,7 +184,14 @@ WemoAccessory.prototype.getServices = function () {
 	service.setCharacteristic(Characteristic.Name, this.name).setCharacteristic(Characteristic.Manufacturer, "WeMo");
 
 	if (this.device.deviceType === Wemo.DEVICE_TYPE.Bridge) {
-		// todo - complete this information
+		// todo - complete this information - if it was available.... which unfortunately it isn't 
+/*
+		service
+            .setCharacteristic(Characteristic.Model, this.enddevice.modelName)
+            .setCharacteristic(Characteristic.SerialNumber, this.enddevice.serialNumber)
+            .setCharacteristic(Characteristic.FirmwareRevision, this.enddevice.firmwareVersion)
+            .setCharacteristic(Characteristic.HardwareRevision, this.enddevice.modelNumber);
+*/
 	}
 	else {
 		service
@@ -232,7 +239,7 @@ WemoAccessory.prototype.getServices = function () {
 
 WemoAccessory.prototype.setOn = function (value, cb) {
 // 	var client = wemo.client(this.device);
-	this.log("setOn: % to %s", this.name, value);
+	this.log("setOn: %s to %s", this.name, value);
 	this._client.setBinaryState(value ? 1 : 0);
 	this.onState = value;
 	if (cb) cb(null);

--- a/index.js
+++ b/index.js
@@ -323,11 +323,20 @@ WemoAccessory.prototype.getServices = function () {
 WemoAccessory.prototype.setOn = function (value, cb) {
 
     if (this.onState != value) {  //remove redundent calls to setBinaryState when requested state is already achieved
-        this.log("setOn: %s to %s", this.name, value > 0 ? "on" : "off");
-        this._client.setBinaryState(value ? 1 : 0);
-        this.onState = value;
-        }
-    if (cb) cb(null);
+//         this.log("setOn: %s to %s", this.name, value > 0 ? "on" : "off");
+        this._client.setBinaryState(value ? 1 : 0, function (err){
+            if(!err) {
+                this.log("setOn: %s to %s", this.name, value > 0 ? "on" : "off");                
+                this.onState = value;
+                if (cb) cb(null);
+            } else {
+                this.log("setOn: FAILED setting %s to %s. Error: %s", this.name, value > 0 ? "on" : "off", err.code);
+                if (cb) cb(new Error(err));
+            }
+        }.bind(this));
+    } else {
+        if (cb) cb(null);
+    }
 }
 
 WemoAccessory.prototype.getOn = function (cb) {

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function WemoPlatform(log, config) {
     this.homekitSafe = config.homekit_safe && (config.homekit_safe > 0 ? true : false) || true; // default to true if not specficied
 
     // if we have been not been told how many accessories to find then homekit safe is off.
-    if(!this.expectedAccessories) { this.homekitSafe = false; }
+    if(this.expectedAccessories == '0') { this.homekitSafe = false; }
 
     noMotionTimer = config.no_motion_timer || 60;
 }

--- a/index.js
+++ b/index.js
@@ -151,7 +151,7 @@ WemoAccessory.prototype.getOnStatus = function (cb) {
 }
 WemoAccessory.prototype.setBrightness = function (value, cb) {
 	var client = wemo.client(this.device);
-	client.setDeviceStatus(this.enddevice.deviceId, 10008, value );
+	client.setDeviceStatus(this.enddevice.deviceId, 10008, value*255/100 );
 	this.log("setBrightness: %s to %s\%", this.name, value);
 	if (cb) cb(null);
 }

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@
 //			"no_motion_timer": 60 // optional: [WeMo Motion only] a timer (in seconds) which is started no motion is detected, defaults to 60
 //		}
 // ],
+
 "use strict";
 
 var Accessory, Characteristic, PowerConsumption, Service, uuid;

--- a/index.js
+++ b/index.js
@@ -1,0 +1,179 @@
+/* jshint node: true */
+// Wemo Platform Plugin for HomeBridge (https://github.com/nfarina/homebridge)
+//
+// Remember to add platform to config.json. Example:
+// "platforms": [
+//     {
+//         "platform": "BelkinWeMo",
+//         "name": "Belkin WeMo",
+//			"expected_accessories": "", stop looking for wemo accessories after this many found (excluding Wemo Link(s))
+//			"timeout": "" //defaults to 10 seconds that we look for accessories.
+//     }
+// ],
+"use strict";
+var Service, Characteristic, Accessory, uuid;
+var Wemo = require('wemo-client');
+var wemo = new Wemo();
+
+module.exports = function (homebridge) {
+	Service = homebridge.hap.Service;
+	Characteristic = homebridge.hap.Characteristic;
+	Accessory = homebridge.hap.Accessory;
+	uuid = homebridge.hap.uuid;
+	homebridge.registerPlatform("homebridge-platform-wemo", "BelkinWeMo", WemoPlatform);
+};
+
+function WemoPlatform(log, config) {
+	this.log = log;
+	this.log("Wemo Platform Plugin Loaded ");
+	this.expectedAccessories = config.expected_accessories || 0;
+	this.timeout = config.timeout || 10;
+}
+WemoPlatform.prototype = {
+	accessories: function (callback) {
+		this.log("Fetching the Wemo Accessories, expecting %s and will wait %s seconds to find them.", 
+			this.expectedAccessories ? this.expectedAccessories : "an unknown number" , this.timeout);
+		var foundAccessories = [];
+		var self = this;
+		wemo.discover(function (device) {
+			self.log("Found: %s", device.friendlyName /* , device.deviceType, device.setupURL */ );
+			if (device.deviceType === Wemo.DEVICE_TYPE.Bridge) { // a wemolink bridge - find bulbs
+				var client = this.client(device);
+				client.getEndDevices(function (err, enddevices) {
+					// this calls us back with an array of enddevices (bulbs)
+// 					self.log("Found: %s enddevices on %s.", enddevices.length, device.friendlyName);
+					for (var i = 0, tot = enddevices.length; i < tot; i++) {
+						self.log("Found endDevice: %s, id: %s", enddevices[i].friendlyName, enddevices[i].deviceId);
+						var accessory = new WemoAccessory(self.log, device, enddevices[i]);
+						foundAccessories.push(accessory);
+						self.log("Discovered %s accessories of %s ", foundAccessories.length, self.expectedAccessories ? self.expectedAccessories : "an unspecified number of accessories")			
+						if (foundAccessories.length == self.expectedAccessories){
+							if (timer) {clearTimeout(timer);}
+							callback(foundAccessories);
+						}
+					}
+				});
+			} else if (device.deviceType === Wemo.DEVICE_TYPE.Switch) {
+				var accessory = new WemoAccessory(self.log, device, null);
+				foundAccessories.push(accessory);
+				self.log("Discovered %s accessories of %s ", foundAccessories.length, self.expectedAccessories ? self.expectedAccessories : "an unspecified number of accessories")			
+				if (foundAccessories.length == self.expectedAccessories){
+					if (timer) {clearTimeout(timer);}
+					callback(foundAccessories);
+				}
+			}
+		});
+
+		// we'll wait here for the accessories to be found unless the specified number of accessories has already been found in which case we'll never get here!!
+
+		var timer = setTimeout(function () {
+			if(self.expectedAccessories) { self.log("We have timed out and only discovered %s of the specified %s devices - try restarting homebridge or increasing timeout in config.json", 
+				foundAccessories.length, self.expectedAccessories) }
+			callback(foundAccessories);
+		}, self.timeout * 1000);
+	},
+};
+
+
+function WemoAccessory(log, device, enddevice) {
+	this.id = device.deviceId;
+	this.name = enddevice ? enddevice.friendlyName : device.friendlyName;
+	this.device = device;
+	this.enddevice = enddevice;
+	this.log = log;
+}
+
+WemoAccessory.prototype.getServices = function () {
+	var services = [];
+	// set up the accessory information - not sure how mandatory any of this is.
+	// todo - complete this information
+	var accessoryInformationService = new Service.AccessoryInformation();
+	accessoryInformationService.setCharacteristic(Characteristic.Name, this.name).setCharacteristic(Characteristic.Manufacturer, "WeMo");
+	services.push(accessoryInformationService);
+	if (this.enddevice) { // we have a lightbulb
+		var lightbulbService = new Service.Lightbulb(this.name);
+		lightbulbService.getCharacteristic(Characteristic.On).on('set', this.setOnStatus.bind(this)).on('get', this.getOnStatus.bind(this));
+		lightbulbService.getCharacteristic(Characteristic.Brightness).on('set', this.setBrightness.bind(this)).on('get', this.getBrightness.bind(this));
+		services.push(lightbulbService);
+	} else { // everything else I have is a switch so that's it for now!
+		var switchService = new Service.Switch(this.name);
+		switchService.getCharacteristic(Characteristic.On).on('set', this.setOn.bind(this)).on('get', this.getOn.bind(this));
+		services.push(switchService);
+	}
+	//	this.log("Services for %s: ", this.name, services);
+	return services;
+};
+WemoAccessory.prototype.setOn = function (value, cb) {
+	var client = wemo.client(this.device);
+	this.log("setOn: % to %s", this.name, value);
+	client.setBinaryState(value ? 1 : 0);
+	if (cb) cb(null);
+}
+WemoAccessory.prototype.getOn = function (cb) {
+	// 	this.log("getOn: %s", this.name);
+	var client = wemo.client(this.device);
+	// 	this.log(client);
+	var self = this;
+	client.getBinaryState(function (err, state) {
+		self.log("getOn: %s is %s ", self.name, state);
+		if (cb) cb(null, (state > 0 ? true : false));
+	});
+}
+WemoAccessory.prototype.setOnStatus = function (value, cb) {
+	var client = wemo.client(this.device);
+	client.setDeviceStatus(this.enddevice.deviceId, 10006, (value ? 1 : 0));
+	this.log("setOnStatus: %s to %s", this.name, value);
+	if (cb) cb(null);
+}
+WemoAccessory.prototype.getOnStatus = function (cb) {
+	var client = wemo.client(this.device);
+	var self = this;
+	client.getDeviceStatus(this.enddevice.deviceId, function (err, state) {
+		if(err) {
+			if(cb) {cb("unknown error getting device status (OnStatus)")}
+			}
+		else {
+			// convert string of capabilities and values to arrays.
+			var capabilities = state.CapabilityID[0].split(',');
+			var capabilityValues = state.CapabilityValue[0].split(',');
+			// extract value if capability 10006 - onState
+			var onState = capabilityValues[capabilities.indexOf('10006')];
+			self.log("getOnStatus: %s is %s", self.name, onState);
+			if (cb) {
+				if (onState) {
+					cb(null, (onState > 0 ? true : false));
+				} else {
+					cb("Currently offline");
+				}
+			}
+		}
+	});
+}
+WemoAccessory.prototype.setBrightness = function (value, cb) {
+	var client = wemo.client(this.device);
+	client.setDeviceStatus(this.enddevice.deviceId, 10008, value );
+	this.log("setBrightness: %s to %s\%", this.name, value);
+	if (cb) cb(null);
+}
+WemoAccessory.prototype.getBrightness = function (cb) {
+	var client = wemo.client(this.device);
+	var self = this;
+	client.getDeviceStatus(this.enddevice.deviceId, function (err, state) {
+		if(err) {
+			if(cb) {cb("unknown error getting device status (Brightness)")}
+			}
+		else {
+			var capabilities = state.CapabilityID[0].split(',');
+			var capabilityValues = state.CapabilityValue[0].split(',');
+			var brightness = Math.round(capabilityValues[capabilities.indexOf('10008')].split(':').shift() / 255 * 100);
+			self.log("getBrightness: %s brightness %s\%", self.name, brightness);
+			if (cb) {
+				if (brightness) {
+					cb(null, brightness);
+				} else {
+					cb("Currently offline")
+				}
+			}
+		}
+	});
+}

--- a/index.js
+++ b/index.js
@@ -49,14 +49,11 @@ function WemoPlatform(log, config) {
     this.log("Wemo Platform Plugin Loaded ");
     this.expectedAccessories = parseInt(config.expected_accessories) || 0; // default to false if not specficied
     this.timeout = config.timeout || 10; // default to 10 seconds if not specified
-    this.homekitSafe = config.homekit_safe && (config.homekit_safe > 0 ? true : false) || true; // default to true if not specficied
-
+    this.homekitSafe = (isNaN(parseInt(config.homekit_safe, 10)) ) ? true : parseInt(config.homekit_safe, 10) > 0 ? true : false;
+        
     // if we have been not been told how many accessories to find then homekit safe is off.
     if(!this.expectedAccessories) { this.homekitSafe = false; }
     
-    log('config:', config);
-    log('homekitsafe:', this.homekitSafe);
-
     noMotionTimer = config.no_motion_timer || 60;
 }
 
@@ -72,7 +69,7 @@ WemoPlatform.prototype = {
                 var client = this.client(device);
                 client.getEndDevices(function (err, enddevices) {
                     // this calls us back with an array of enddevices (bulbs)
-                    self.log("%s EndDevices found in:", enddevices.length, enddevices );
+                    self.log("%s EndDevices found in:", enddevices.length );
                     for (var i = 0, tot = enddevices.length; i < tot; i++) {
                         self.log("Found endDevice: %s, id: %s", enddevices[i].friendlyName, enddevices[i].deviceId);
                         var accessory = new WemoAccessory(self.log, device, enddevices[i]);

--- a/index.js
+++ b/index.js
@@ -47,12 +47,12 @@ module.exports = function (homebridge) {
 function WemoPlatform(log, config) {
     this.log = log;
     this.log("Wemo Platform Plugin Loaded ");
-    this.expectedAccessories = config.expected_accessories || 0; // default to false if not specficied
+    this.expectedAccessories = parseInt(config.expected_accessories) || 0; // default to false if not specficied
     this.timeout = config.timeout || 10; // default to 10 seconds if not specified
     this.homekitSafe = config.homekit_safe && (config.homekit_safe > 0 ? true : false) || true; // default to true if not specficied
 
     // if we have been not been told how many accessories to find then homekit safe is off.
-    if(this.expectedAccessories == '0') { this.homekitSafe = false; }
+    if(!this.expectedAccessories) { this.homekitSafe = false; }
 
     noMotionTimer = config.no_motion_timer || 60;
 }
@@ -69,6 +69,7 @@ WemoPlatform.prototype = {
                 var client = this.client(device);
                 client.getEndDevices(function (err, enddevices) {
                     // this calls us back with an array of enddevices (bulbs)
+                    self.log("%s EndDevices found in:", enddevices.length, enddevices );
                     for (var i = 0, tot = enddevices.length; i < tot; i++) {
                         self.log("Found endDevice: %s, id: %s", enddevices[i].friendlyName, enddevices[i].deviceId);
                         var accessory = new WemoAccessory(self.log, device, enddevices[i]);

--- a/index.js
+++ b/index.js
@@ -193,14 +193,14 @@ WemoAccessory.prototype._statusChange = function(deviceId, capabilityId, value) 
     */
     if (this.enddevice.deviceId != deviceId){
         // we get called for every bulb on the link so lets get out of here if the call is for a differnt bulb
-        this.log('statusChange Ignored (device): ', this.enddevice.deviceId, deviceId, capabilityId, value)
+        this.log('statusChange Ignored (device): ', this.enddevice.deviceId, deviceId, capabilityId, value);
         return;
         }
     
     if (this._capabilities[capabilityId] === value) {
         // nothing's changed - lets get out of here to stop an endless loop as 
         // this callback was probably triggered by us updating HomeKit
-        this.log('statusChange Ignored (capability): ', deviceId, capabilityId, value)
+        this.log('statusChange Ignored (capability): ', deviceId, capabilityId, value);
         return;
         }
 
@@ -359,8 +359,8 @@ WemoAccessory.prototype.getStatus = function (cb) {
 WemoAccessory.prototype.setOnStatus = function (value, cb) {
 //  var client = wemo.client(this.device);
     this.onState = value;
-    this._client.setDeviceStatus(this.enddevice.deviceId, 10006, (value ? 1 : 0));
     this.log("setOnStatus: %s to %s", this.name, value > 0 ? "on" : "off");
+    this._client.setDeviceStatus(this.enddevice.deviceId, 10006, (value ? 1 : 0));
     if (cb) cb(null);
 }
 

--- a/index.js
+++ b/index.js
@@ -53,6 +53,9 @@ function WemoPlatform(log, config) {
 
     // if we have been not been told how many accessories to find then homekit safe is off.
     if(!this.expectedAccessories) { this.homekitSafe = false; }
+    
+    log('config:', config);
+    log('homekitsafe:', this.homekitSafe);
 
     noMotionTimer = config.no_motion_timer || 60;
 }

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ WemoPlatform.prototype = {
         wemo.discover(function (device) {
             self.log("Found: %s, type: %s", device.friendlyName, device.deviceType.split(":")[3]);
             if (device.deviceType === Wemo.DEVICE_TYPE.Bridge) { // a wemolink bridge - find bulbs
-                var client = this.client(device);
+                var client = this.client(device , self.log);
                 client.getEndDevices(function (err, enddevices) {
                     // this calls us back with an array of enddevices (bulbs)
                     self.log("%s EndDevices found in:", enddevices.length );
@@ -120,7 +120,7 @@ function WemoAccessory(log, device, enddevice) {
 
     this.device = device;
     this.log = log;
-    this._client = wemo.client(device);
+    this._client = wemo.client(device, log);
 
     if(device.deviceType === Wemo.DEVICE_TYPE.Bridge) {
         this.id = device.deviceId;

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ WemoPlatform.prototype = {
                         self.log("Discovered %s accessories of %s ",
                                     foundAccessories.length,
                                     self.expectedAccessories ? self.expectedAccessories : "an unspecified number of accessories")
-                        if (foundAccessories.length == self.expectedAccessories){
+                        if (foundAccessories.length === self.expectedAccessories){
                             if (timer) {clearTimeout(timer);}
                             callback(foundAccessories);
                         }
@@ -89,7 +89,7 @@ WemoPlatform.prototype = {
                 self.log("Discovered %s accessories of %s ",
                             foundAccessories.length,
                             self.expectedAccessories ? self.expectedAccessories : "an unspecified number of accessories");
-                if (foundAccessories.length == self.expectedAccessories)
+                if (foundAccessories.length === self.expectedAccessories)
                     {
                     self.log("Woohoo!!! all %s accessories found.", self.expectedAccessories );
                     if (timer) {clearTimeout(timer);} // if setTimeout got called already cancel it.
@@ -157,8 +157,8 @@ function WemoAccessory(log, device, enddevice) {
             self.onState = state > 0 ? true : false ;
 
             if (self.service) {
-                if (self.onState != self._onState) {
-                    if (self.device.deviceType == Wemo.DEVICE_TYPE.Motion || self.device.deviceType == "urn:Belkin:device:NetCamSensor:1") {
+                if (self.onState !== self._onState) {
+                    if (self.device.deviceType === Wemo.DEVICE_TYPE.Motion || self.device.deviceType === "urn:Belkin:device:NetCamSensor:1") {
                         self.updateMotionDetected();
                     }
                     else {
@@ -181,7 +181,7 @@ function WemoAccessory(log, device, enddevice) {
         if(device.deviceType === Wemo.DEVICE_TYPE.Insight) {
             this._client.on('insightParams', function(state, power){
                 //self.log('%s inUse: %s', this.name, state);
-                self.inUse = state == 1 ? true : false ;
+                self.inUse = state === 1 ? true : false ;
                 self.powerUsage = Math.round(power / 100) / 10;
 
                 if (self.service) {
@@ -202,7 +202,7 @@ WemoAccessory.prototype._statusChange = function(deviceId, capabilityId, value) 
          to do that we need to use setValue which triggers another call back to here which
          we need to ignore - much of this function deals with the idiosyncrasies around this issue.
     */
-    if (this.enddevice.deviceId != deviceId){
+    if (this.enddevice.deviceId !== deviceId){
         // we get called for every bulb on the link so lets get out of here if the call is for a differnt bulb
         this.log('statusChange Ignored (device): ', this.enddevice.deviceId, deviceId, capabilityId, value);
         return;
@@ -323,7 +323,7 @@ WemoAccessory.prototype.getServices = function () {
 
 WemoAccessory.prototype.setOn = function (value, cb) {
 
-    if (this.onState != value) {  //remove redundent calls to setBinaryState when requested state is already achieved
+    if (this.onState !== value) {  //remove redundent calls to setBinaryState when requested state is already achieved
 //         this.log("setOn: %s to %s", this.name, value > 0 ? "on" : "off");
         this._client.setBinaryState(value ? 1 : 0, function (err){
             if(!err) {
@@ -379,7 +379,7 @@ WemoAccessory.prototype.getStatus = function (cb) {
 WemoAccessory.prototype.setOnStatus = function (value, cb) {
 //  var client = wemo.client(this.device);
     debug("this.Onstate currently %s, value is %s", this.onState, value );
-    if(this.onState != value) { // if we have nothing to do so lets leave it at that.
+    if(this.onState !== value) { // if we have nothing to do so lets leave it at that.
         this.onState = value;
         debug("this.Onstate now: %s", this.onState);
         this.log("setOnStatus: %s to %s", this.name, value > 0 ? "on" : "off");
@@ -396,7 +396,7 @@ WemoAccessory.prototype.getOnStatus = function (cb) {
 
 WemoAccessory.prototype.setBrightness = function (value, cb) {
 //  var client = wemo.client(this.device);
-    if(this.brightness != value) { // we have nothing to do so lets leave it at that.
+    if(this.brightness !== value) { // we have nothing to do so lets leave it at that.
         this._client.setDeviceStatus(this.enddevice.deviceId, 10008, value*255/100 );
         this.log("setBrightness: %s to %s%%", this.name, value);
         this.brightness = value;
@@ -410,7 +410,7 @@ WemoAccessory.prototype.getBrightness = function (cb) {
 }
 
 WemoAccessory.prototype.updateInUse = function () {
-    if (this.inUse != this._inUse) {
+    if (this.inUse !== this._inUse) {
         this.service.getCharacteristic(Characteristic.OutletInUse).setValue(this.inUse);
         this._inUse = this.inUse;
     }
@@ -442,7 +442,7 @@ WemoAccessory.prototype.updateMotionDetected = function() {
 }
 
 WemoAccessory.prototype.updatePowerUsage = function () {
-    if (this.powerUsage != this._powerUsage) {
+    if (this.powerUsage !== this._powerUsage) {
         this.service.getCharacteristic(PowerConsumption).setValue(this.powerUsage);
         this._powerUsage = this.powerUsage;
     }

--- a/index.js
+++ b/index.js
@@ -287,9 +287,13 @@ WemoAccessory.prototype.getStatus = function (cb) {
 			if(cb) {cb("unknown error getting device status (getStatus)", capabilities)}
 			}
 		else {
-			// convert string of capabilities and values to arrays.
-			self._capabilities = capabilities;
-			self.log("getStatus: %s is ", self.name, capabilities);
+			if (!capabilities['10006'].length) { // we've get no data in the capabilities array, so it's off
+				self.log("%s appears to be off, i.e. at the power!",self.name);
+				}
+			else {
+				self.log("getStatus: %s is ", self.name, capabilities);
+				self._capabilities = capabilities;
+				}
 			if (cb) { cb(null) }
 			}
 		});

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ WemoPlatform.prototype = {
 		var foundAccessories = [];
 		var self = this;
 		wemo.discover(function (device) {
-			self.log("Found: %s", device.friendlyName);
+			self.log("Found: %s, type %s", device.friendlyName, device.deviceType);
 			if (device.deviceType === Wemo.DEVICE_TYPE.Bridge) { // a wemolink bridge - find bulbs
 				var client = this.client(device);
 				client.getEndDevices(function (err, enddevices) {
@@ -54,7 +54,8 @@ WemoPlatform.prototype = {
 					}
 				});
 			} else if (device.deviceType === Wemo.DEVICE_TYPE.Switch 
-					|| device.deviceType === Wemo.DEVICE_TYPE.Insight) {
+					|| device.deviceType === Wemo.DEVICE_TYPE.Insight
+					|| device.deviceType === "urn:Belkin:device:lightswitch:1") {
 				var accessory = new WemoAccessory(self.log, device, null);
 				foundAccessories.push(accessory);
 				self.log("Discovered %s accessories of %s ", foundAccessories.length, self.expectedAccessories ? self.expectedAccessories : "an unspecified number of accessories")			

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@
 //     }
 // ],
 "use strict";
+
 var Service, Characteristic, Accessory, uuid;
 var Wemo = require('wemo-client');
 var wemo = new Wemo();
@@ -26,8 +27,8 @@ module.exports = function (homebridge) {
 function WemoPlatform(log, config) {
 	this.log = log;
 	this.log("Wemo Platform Plugin Loaded ");
-	this.expectedAccessories = config.expected_accessories || 0;
-	this.timeout = config.timeout || 10;
+	this.expectedAccessories = config.expected_accessories || 0 ; // default to false if not specficied
+	this.timeout = config.timeout || 10; // default to 10 seconds if not specified
 }
 WemoPlatform.prototype = {
 	accessories: function (callback) {
@@ -36,12 +37,11 @@ WemoPlatform.prototype = {
 		var foundAccessories = [];
 		var self = this;
 		wemo.discover(function (device) {
-			self.log("Found: %s", device.friendlyName /* , device.deviceType, device.setupURL */ );
+			self.log("Found: %s", device.friendlyName);
 			if (device.deviceType === Wemo.DEVICE_TYPE.Bridge) { // a wemolink bridge - find bulbs
 				var client = this.client(device);
 				client.getEndDevices(function (err, enddevices) {
 					// this calls us back with an array of enddevices (bulbs)
-// 					self.log("Found: %s enddevices on %s.", enddevices.length, device.friendlyName);
 					for (var i = 0, tot = enddevices.length; i < tot; i++) {
 						self.log("Found endDevice: %s, id: %s", enddevices[i].friendlyName, enddevices[i].deviceId);
 						var accessory = new WemoAccessory(self.log, device, enddevices[i]);
@@ -53,7 +53,8 @@ WemoPlatform.prototype = {
 						}
 					}
 				});
-			} else if (device.deviceType === Wemo.DEVICE_TYPE.Switch) {
+			} else if (device.deviceType === Wemo.DEVICE_TYPE.Switch 
+					|| device.deviceType === Wemo.DEVICE_TYPE.Insight) {
 				var accessory = new WemoAccessory(self.log, device, null);
 				foundAccessories.push(accessory);
 				self.log("Discovered %s accessories of %s ", foundAccessories.length, self.expectedAccessories ? self.expectedAccessories : "an unspecified number of accessories")			
@@ -79,9 +80,57 @@ function WemoAccessory(log, device, enddevice) {
 	this.id = device.deviceId;
 	this.name = enddevice ? enddevice.friendlyName : device.friendlyName;
 	this.device = device;
-	this.enddevice = enddevice;
+	this.enddevice = enddevice;  // this is used as a flag to determine a bulb or a switch at time i.e. null = switch.
 	this.log = log;
+	this._client = wemo.client(device);	
+	this.brightness = null;
+	this._internalState = enddevice ? enddevice.internalState : null;
+	// set onState for convenience.	
+	if(enddevice) {
+		this.onState = (this._internalState['10006'].substr(0,1) === '1') ? true : false ;
+		this.log("%s is %s", this.name, this.onState, this._internalState['10006'].substr(0,1));
+	} else {
+		this.onState = device.binaryState > 0 ? true : false ;
+		this.log("%s is %s", this.name, this.onState);
+	}
+	
+	// set brightness for convenience.
+	if(enddevice) {
+		this.brightness = Math.round(this._internalState['10008'].split(':').shift() / 255 * 100 );
+		this.log("%s is %s bright", this.name, this.brightness);
+		}
+
+//	this.log(this.name , device, enddevice);
+
+ 	var self = this;
+ 	
+	this._client.on('binaryState', function(state){
+		if (!self.enddevice) { // we seem to get a spurious binaryState on lights - ignore them!
+			self.log('%s binaryState: %s', this.name, state);
+	    	self.onState = state > 0 ? true : false ;
+	    	}
+  		}.bind(this));
+  		
+ 
+  	this._client.on('statusChange', function(deviceId, capabilityId, value) {
+// 	    if (deviceId === self.deviceId) {
+//	   	  self.log('statusChange: %s', self.name, self, deviceId, capabilityId, value, this._internalState);
+	      self._statusChange(deviceId, capabilityId, value);
+// 	    	}
+			});
 }
+
+WemoAccessory.prototype._statusChange = function(deviceId, capabilityId, value) {
+   this.log('statusChange: %s', deviceId, capabilityId, value);
+   this._internalState[capabilityId] = value;
+   if (capabilityId ==='10008') {
+	   this.brightness = Math.round(this._internalState['10008'].split(':').shift() / 255 * 100 );
+	   this._internalState['10006'] = '1';  //changing wemo bulb brightness always turns them on so lets reflect this! 
+	   }
+	   
+   this.onState = (this._internalState['10006'].substr(0,1) === '1') ? true : false;
+}
+
 
 WemoAccessory.prototype.getServices = function () {
 	var services = [];
@@ -104,31 +153,28 @@ WemoAccessory.prototype.getServices = function () {
 	return services;
 };
 WemoAccessory.prototype.setOn = function (value, cb) {
-	var client = wemo.client(this.device);
+// 	var client = wemo.client(this.device);
 	this.log("setOn: % to %s", this.name, value);
-	client.setBinaryState(value ? 1 : 0);
+	this._client.setBinaryState(value ? 1 : 0);
+	this.onState = value;
 	if (cb) cb(null);
+
 }
 WemoAccessory.prototype.getOn = function (cb) {
-	// 	this.log("getOn: %s", this.name);
-	var client = wemo.client(this.device);
-	// 	this.log(client);
-	var self = this;
-	client.getBinaryState(function (err, state) {
-		self.log("getOn: %s is %s ", self.name, state);
-		if (cb) cb(null, (state > 0 ? true : false));
-	});
+	this.log("getOn: %s is %s ", this.name, this.onState);
+	if (cb) cb(null, this.onState);
 }
 WemoAccessory.prototype.setOnStatus = function (value, cb) {
-	var client = wemo.client(this.device);
-	client.setDeviceStatus(this.enddevice.deviceId, 10006, (value ? 1 : 0));
+// 	var client = wemo.client(this.device);
+	this._client.setDeviceStatus(this.enddevice.deviceId, 10006, (value ? 1 : 0));
 	this.log("setOnStatus: %s to %s", this.name, value);
 	if (cb) cb(null);
 }
 WemoAccessory.prototype.getOnStatus = function (cb) {
-	var client = wemo.client(this.device);
+// 	var client = wemo.client(this.device);
+/*
 	var self = this;
-	client.getDeviceStatus(this.enddevice.deviceId, function (err, state) {
+	this._client.getDeviceStatus(this.enddevice.deviceId, function (err, state) {
 		if(err) {
 			if(cb) {cb("unknown error getting device status (OnStatus)")}
 			}
@@ -148,17 +194,25 @@ WemoAccessory.prototype.getOnStatus = function (cb) {
 			}
 		}
 	});
+*/
+	this.log("getOnStatus: %s is %s", this.name, this.onState)
+	if(cb) cb(null, this.onState);
 }
 WemoAccessory.prototype.setBrightness = function (value, cb) {
-	var client = wemo.client(this.device);
-	client.setDeviceStatus(this.enddevice.deviceId, 10008, value*255/100 );
+// 	var client = wemo.client(this.device);
+	this._client.setDeviceStatus(this.enddevice.deviceId, 10008, value*255/100 );
 	this.log("setBrightness: %s to %s\%", this.name, value);
 	if (cb) cb(null);
 }
 WemoAccessory.prototype.getBrightness = function (cb) {
-	var client = wemo.client(this.device);
+	this.log("getBrightness: %s is %s", this.name, this.brightness)
+	if(cb) cb(null, this.brightness);
+	
+	
+// 	var client = wemo.client(this.device);
+/*
 	var self = this;
-	client.getDeviceStatus(this.enddevice.deviceId, function (err, state) {
+	this._client.getDeviceStatus(this.enddevice.deviceId, function (err, state) {
 		if(err) {
 			if(cb) {cb("unknown error getting device status (Brightness)")}
 			}
@@ -176,4 +230,5 @@ WemoAccessory.prototype.getBrightness = function (cb) {
 			}
 		}
 	});
+*/
 }

--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ WemoPlatform.prototype = {
                 self.log("We have timed out and only discovered %s of the specified %s devices - try restarting homebridge or increasing timeout in config.json",
                     foundAccessories.length, self.expectedAccessories);
                 if(self.homekitSafe) {
-                    self.log("and you have indicited you'd like to keep your HomeKit config safe so we're crashing out");
+                    self.log("and you have indicated you'd like to keep your HomeKit config safe so we're crashing out");
                     throw new Error("homebridge-wemo-platform has intentially bought down HomeBridge - please restart - sorry but it's your HomeKit configuration we're protecting!");
                 }
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-wemo",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "WeMo Platform plugin for homebridge - Blubs, Switches and Insight Switches Supported",
   "license": "ISC",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-wemo",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "WeMo Platform plugin for homebridge - Blubs, Switches and Insight Switches Supported",
   "license": "ISC",
   "keywords": [
@@ -19,6 +19,6 @@
 
   "dependencies": {
     "request": "^2.65.0",
-    "wemo-client": "*"
+    "wemo-client": "^0.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-wemo",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "WeMo Platform plugin for homebridge - Blubs, Switches and Insight Switches Supported",
   "license": "ISC",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-wemo",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "WeMo Platform plugin for homebridge - Blubs, Switches and Insight Switches Supported",
   "license": "ISC",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-wemo",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "WeMo Platform plugin for homebridge",
   "license": "ISC",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-wemo",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "WeMo Platform plugin for homebridge - Blubs, Switches and Insight Switches Supported",
   "license": "ISC",
   "keywords": [
@@ -19,6 +19,6 @@
 
   "dependencies": {
     "request": "^2.65.0",
-    "wemo-client": ""
+    "wemo-client": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-wemo",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "WeMo Platform plugin for homebridge - Blubs, Switches and Insight Switches Supported",
   "license": "ISC",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-wemo",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "WeMo Platform plugin for homebridge - Blubs, Switches and Insight Switches Supported",
   "license": "ISC",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-wemo",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "WeMo Platform plugin for homebridge - Blubs, Switches and Insight Switches Supported",
   "license": "ISC",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-wemo",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "WeMo Platform plugin for homebridge - Blubs, Switches and Insight Switches Supported",
   "license": "ISC",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-wemo",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "WeMo Platform plugin for homebridge - Blubs, Switches and Insight Switches Supported",
   "license": "ISC",
   "keywords": [
@@ -19,6 +19,7 @@
 
   "dependencies": {
     "request": "^2.65.0",
-    "wemo-client": "^0.6.2"
+    "wemo-client": "^0.6.2",
+    "debug" : "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-wemo",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "WeMo Platform plugin for homebridge - Blubs, Switches and Insight Switches Supported",
   "license": "ISC",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-wemo",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "WeMo Platform plugin for homebridge",
   "license": "ISC",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-wemo",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "WeMo Platform plugin for homebridge - Blubs, Switches and Insight Switches Supported",
   "license": "ISC",
   "keywords": [
@@ -19,6 +19,6 @@
 
   "dependencies": {
     "request": "^2.65.0",
-    "wemo-client": "https://github.com/rudders/wemo-client.git"
+    "wemo-client": "^0.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-wemo",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "WeMo Platform plugin for homebridge - Blubs, Switches and Insight Switches Supported",
   "license": "ISC",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-wemo",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "WeMo Platform plugin for homebridge - Blubs, Switches and Insight Switches Supported",
   "license": "ISC",
   "keywords": [
@@ -19,7 +19,7 @@
 
   "dependencies": {
     "request": "^2.65.0",
-    "wemo-client": "https://github.com/rudders/wemo-client.git#bulb-groups",
+    "wemo-client": "https://github.com/rudders/wemo-client.git",
     "debug" : "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-platform-wemo",
-  "version": "0.0.3",
-  "description": "WeMo Platform plugin for homebridge",
+  "version": "0.5.0",
+  "description": "WeMo Platform plugin for homebridge - Blubs, Switches and Insight Switches Supported",
   "license": "ISC",
   "keywords": [
     "homebridge-plugin"
@@ -19,6 +19,6 @@
 
   "dependencies": {
     "request": "^2.65.0",
-    "wemo-client": "https://github.com/rudders/wemo-client.git"
+    "wemo-client": ""
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 
   "dependencies": {
     "request": "^2.65.0",
-    "wemo-client": "https://github.com/rudders/wemo-client.git",
+    "wemo-client": "https://github.com/rudders/wemo-client#bulb-groups",
     "debug" : "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,20 +6,17 @@
   "keywords": [
     "homebridge-plugin"
   ],
-
   "repository": {
     "type": "git",
     "url": "git://github.com/rudders/homebridge-platform-wemo.git"
   },
-
   "engines": {
     "node": ">=0.12.0",
     "homebridge": ">=0.2.0"
   },
-
   "dependencies": {
     "request": "^2.65.0",
     "wemo-client": "https://github.com/rudders/wemo-client.git",
-    "debug" : "*"
+    "debug": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 
   "dependencies": {
     "request": "^2.65.0",
-    "wemo-client": "https://github.com/rudders/wemo-client#bulb-groups",
+    "wemo-client": "https://github.com/rudders/wemo-client.git#bulb-groups",
     "debug" : "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-wemo",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "WeMo Platform plugin for homebridge - Blubs, Switches and Insight Switches Supported",
   "license": "ISC",
   "keywords": [
@@ -19,6 +19,6 @@
 
   "dependencies": {
     "request": "^2.65.0",
-    "wemo-client": "^0.6.1"
+    "wemo-client": "https://github.com/rudders/wemo-client.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-wemo",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "WeMo Platform plugin for homebridge - Blubs, Switches and Insight Switches Supported",
   "license": "ISC",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-wemo",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "WeMo Platform plugin for homebridge - Blubs, Switches and Insight Switches Supported",
   "license": "ISC",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-wemo",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "WeMo Platform plugin for homebridge - Blubs, Switches and Insight Switches Supported",
   "license": "ISC",
   "keywords": [
@@ -19,7 +19,7 @@
 
   "dependencies": {
     "request": "^2.65.0",
-    "wemo-client": "^0.6.2",
+    "wemo-client": "https://github.com/rudders/wemo-client.git",
     "debug" : "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "homebridge-platform-wemo",
+  "version": "0.0.1",
+  "description": "WeMo Platform plugin for homebridge: https://github.com/nfarina/homebridge",
+  "license": "ISC",
+  "keywords": [
+    "homebridge-plugin"
+  ],
+
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/rudders/homebridge-platform-wemo.git"
+  },
+
+  "engines": {
+    "node": ">=0.12.0",
+    "homebridge": ">=0.2.0"
+  },
+
+  "dependencies": {
+    "request": "^2.65.0",
+    "wemo-client": "https://github.com/rudders/wemo-client.git"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-platform-wemo",
   "version": "0.0.1",
-  "description": "WeMo Platform plugin for homebridge: https://github.com/nfarina/homebridge",
+  "description": "WeMo Platform plugin for homebridge",
   "license": "ISC",
   "keywords": [
     "homebridge-plugin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-platform-wemo",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "WeMo Platform plugin for homebridge - Blubs, Switches and Insight Switches Supported",
   "license": "ISC",
   "keywords": [


### PR DESCRIPTION
This PR is a rewrite of the `homebridge-platform-wemo` to take advantage of changes added to `Homebridge`.

The biggest change of all is device persistence, so if devices aren't on the network for some reason, doing a restart doesn't remove them from HomeKit.

From a code perspective, this PR separates WeMo devices and WeMo Link devices into two different accessories (`WemoAccessory` and `WemoLinkAccessory`). This mainly to simplify things for code maintainability.
