### PR TITLE
Add err as first param to addDiscoveredDevice

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ function WemoPlatform(log, config, api) {
     doorOpenTimer = this.config.doorOpenTimer || DEFAULT_DOOR_OPEN_TIME;
     noMotionTimer = this.config.noMotionTimer || this.config.no_motion_timer || DEFAULT_NO_MOTION_TIME;
 
-    var addDiscoveredDevice = function(device) {
+    var addDiscoveredDevice = function(err, device) {
         var uuid = UUIDGen.generate(device.UDN);
         var accessory;
 


### PR DESCRIPTION
Workaround to #96 
API change in wemo-client 0.13 adds err as first parameter to the callback.
My node knowledge is rather limited right now so I don't do anything with err, I'll leave that to someone who knows what they are doing.
