### PR TITLE
Added basic dimmer support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ npm-debug.log
 .node-version
 
 *.bak
+
+.idea/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "node_modules/wemo-client"]
-	path = node_modules/wemo-client
-	url = https://github.com/timonreinhard/wemo-client.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "node_modules/wemo-client"]
+	path = node_modules/wemo-client
+	url = https://github.com/timonreinhard/wemo-client.git

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Belkin WeMo Platform plugin for the awesome  [Homebridge](https://github.com/nfa
 ## Currently supports
 - Wemo Switch
 - Wemo Light Switch 
+- Wemo Dimmer (As Light Switch, no dimming)
 - Wemo Insight Switch
 - Wemo Bulb (via Wemo Link - on/off/brightness)
 - Wemo Maker (as Garage Door Opener or Switch with Contact Sensor)

--- a/index.js
+++ b/index.js
@@ -184,9 +184,9 @@ WemoPlatform.prototype.addAccessory = function(device) {
         case Wemo.DEVICE_TYPE.LightSwitch:
             serviceType = Service.Switch;
             break;
-        case Wemo.DEVICE_TYPE.Dimmer:
-            serviceType = Service.Switch;
-            break;
+        // case Wemo.DEVICE_TYPE.Dimmer:
+        //     serviceType = Service.Switch;
+        //     break;
         case Wemo.DEVICE_TYPE.Motion:
         case "urn:Belkin:device:NetCamSensor:1":
             serviceType = Service.MotionSensor;

--- a/index.js
+++ b/index.js
@@ -185,7 +185,7 @@ WemoPlatform.prototype.addAccessory = function(device) {
             serviceType = Service.Switch;
             break;
         case Wemo.DEVICE_TYPE.Dimmer:
-            serviceType = Service.Switch;
+            serviceType = Service.Dimmer;
             break;
         case Wemo.DEVICE_TYPE.Motion:
         case "urn:Belkin:device:NetCamSensor:1":

--- a/index.js
+++ b/index.js
@@ -185,7 +185,7 @@ WemoPlatform.prototype.addAccessory = function(device) {
             serviceType = Service.Switch;
             break;
         case Wemo.DEVICE_TYPE.Dimmer:
-            serviceType = Service.Dimmer;
+            serviceType = Service.Switch;
             break;
         case Wemo.DEVICE_TYPE.Motion:
         case "urn:Belkin:device:NetCamSensor:1":

--- a/index.js
+++ b/index.js
@@ -185,7 +185,7 @@ WemoPlatform.prototype.addAccessory = function(device) {
             serviceType = Service.Switch;
             break;
         case Wemo.DEVICE_TYPE.Dimmer:
-            serviceType = Service.Lightbulb;
+            serviceType = Service.Dimmer;
             break;
         case Wemo.DEVICE_TYPE.Motion:
         case "urn:Belkin:device:NetCamSensor:1":

--- a/index.js
+++ b/index.js
@@ -181,6 +181,7 @@ WemoPlatform.prototype.addAccessory = function(device) {
         case Wemo.DEVICE_TYPE.Switch:
             serviceType = Service.Outlet;
             break;
+        case Wemo.DEVICE_TYPE.Dimmer:
         case Wemo.DEVICE_TYPE.LightSwitch:
             serviceType = Service.Switch;
             break;

--- a/index.js
+++ b/index.js
@@ -184,9 +184,9 @@ WemoPlatform.prototype.addAccessory = function(device) {
         case Wemo.DEVICE_TYPE.LightSwitch:
             serviceType = Service.Switch;
             break;
-        // case Wemo.DEVICE_TYPE.Dimmer:
-        //     serviceType = Service.Switch;
-        //     break;
+        case Wemo.DEVICE_TYPE.Dimmer:
+            serviceType = Service.Lightbulb;
+            break;
         case Wemo.DEVICE_TYPE.Motion:
         case "urn:Belkin:device:NetCamSensor:1":
             serviceType = Service.MotionSensor;

--- a/index.js
+++ b/index.js
@@ -181,9 +181,11 @@ WemoPlatform.prototype.addAccessory = function(device) {
         case Wemo.DEVICE_TYPE.Switch:
             serviceType = Service.Outlet;
             break;
-        case Wemo.DEVICE_TYPE.Dimmer:
         case Wemo.DEVICE_TYPE.LightSwitch:
             serviceType = Service.Switch;
+            break;
+        case Wemo.DEVICE_TYPE.Dimmer:
+            serviceType = Service.Lightbulb;
             break;
         case Wemo.DEVICE_TYPE.Motion:
         case "urn:Belkin:device:NetCamSensor:1":

--- a/index.js
+++ b/index.js
@@ -185,7 +185,7 @@ WemoPlatform.prototype.addAccessory = function(device) {
             serviceType = Service.Switch;
             break;
         case Wemo.DEVICE_TYPE.Dimmer:
-            serviceType = Service.Lightbulb;
+            serviceType = Service.Switch;
             break;
         case Wemo.DEVICE_TYPE.Motion:
         case "urn:Belkin:device:NetCamSensor:1":

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "homebridge-platform-wemo",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "WeMo Platform plugin for homebridge - Blubs, Switches and Insight Switches Supported",
     "license": "ISC",
     "keywords": [
@@ -8,14 +8,14 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git://github.com/rudders/homebridge-platform-wemo.git"
+        "url": "git@github.com:markhatchell/homebridge-platform-wemo.git"
     },
     "engines": {
         "node": ">=0.12.0",
         "homebridge": ">=0.4.1"
     },
     "dependencies": {
-        "wemo-client": ">=0.13.0",
+        "wemo-client": "https://github.com/markhatchell/wemo-client.git#master",
         "debug": "*"
     }
 }

--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git@github.com:markhatchell/homebridge-platform-wemo.git"
+        "url": "git://github.com/rudders/homebridge-platform-wemo.git"
     },
     "engines": {
         "node": ">=0.12.0",
         "homebridge": ">=0.4.1"
     },
     "dependencies": {
-        "wemo-client": "https://github.com/markhatchell/wemo-client.git#master",
+        "wemo-client": ">=0.13.0",
         "debug": "*"
     }
 }


### PR DESCRIPTION
Added demo dimmer as a switch for binary state options. No dimming support yet.

This PR is dependent on the PR in wemo-client  https://github.com/timonreinhard/wemo-client/pull/54 

Once that has been merged in to wemo-client then this can be merged in.