### PR TITLE
Support optional config value "discoveryInterval"

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,11 +6,12 @@
 //      {
 //          "platform": "BelkinWeMo",
 //          "name": "Belkin WeMo",
-//          "noMotionTimer": 60,  // optional: [WeMo Motion only] a timer (in seconds) which is started no motion is detected, defaults to 60
-//          "ignoredDevices": [], // optional: an array of Device serial numbers to ignore
-//          "manualDevices": [],  // optional: an array of config urls for devices to be manually configured eg. "manualDevices": ["http://192.168.1.20:49153/setup.xml"]
-//          "discovery": true,    // optional: turn off device discovery if not required
-//          "wemoClient": {}      // optional: initialisation parameters to be passed to wemo-client
+//          "noMotionTimer": 60,    // optional: [WeMo Motion only] a timer (in seconds) which is started no motion is detected, defaults to 60
+//          "ignoredDevices": [],   // optional: an array of Device serial numbers to ignore
+//          "manualDevices": [],    // optional: an array of config urls for devices to be manually configured eg. "manualDevices": ["http://192.168.1.20:49153/setup.xml"]
+//          "discovery": true,      // optional: turn off device discovery if not required
+//          "discoveryInterval": 30 // optional: the interval in seconds at which to send ssdp-search requests
+//          "wemoClient": {}        // optional: initialisation parameters to be passed to wemo-client
 //      }
 // ],
 
@@ -86,6 +87,7 @@ function WemoPlatform(log, config, api) {
     }
 
     this.discovery = this.config.discovery || true;
+    this.discoveryInterval = this.config.discoveryInterval || 30;
     this.ignoredDevices = this.config.ignoredDevices || [];
     this.manualDevices = this.config.manualDevices || [];
 
@@ -172,7 +174,7 @@ function WemoPlatform(log, config, api) {
             function(){
                 wemo.discover(addDiscoveredDevice);
             },
-            30000
+            this.discoveryInterval * 1000
         );
     }
 }


### PR DESCRIPTION
The interval in seconds at which SSDP-SEARCH packets are broadcasted to the network. The default 30s was a bit too often in a populated network. Will influence the time it takes for new devices to be found. Add e.g.
"discoveryInterval": 300
to your homebridge config.js file in the wemo platform section.